### PR TITLE
refactor(msnbasexic): separate analytes TSV into its own input channel

### DIFF
--- a/modules/local/msnbasexic/main.nf
+++ b/modules/local/msnbasexic/main.nf
@@ -10,7 +10,8 @@ process MSNBASEXIC {
     'community.wave.seqera.io/library/bioconductor-msnbase_r-ggplot2_r-optparse_r-pracma_r-readr:83cd263d3bfd0c9e' }"
 
     input:
-        tuple val(meta), path(mzml_file), path(tsv_file)
+        tuple val(meta), path(mzml_file)
+        path tsv_file
         val analyte
         val rt_tol_sec
         val mz_tol_ppm

--- a/modules/local/msnbasexic/main.nf
+++ b/modules/local/msnbasexic/main.nf
@@ -12,14 +12,6 @@ process MSNBASEXIC {
     input:
         tuple val(meta), path(mzml_file)
         path tsv_file
-        val analyte
-        val rt_tol_sec
-        val mz_tol_ppm
-        val msLevel
-        val plot_xic_ms1
-        val plot_xic_ms2
-        val plot_output_path
-        val overwrite_tsv
 
     output:
         tuple val(meta), path("*.tsv"), emit: xic_output

--- a/workflows/ribomsqc.nf
+++ b/workflows/ribomsqc.nf
@@ -37,7 +37,7 @@ workflow RIBOMSQC {
     // MODULE: Run MSNBASEXIC
     //
     mzml_ch             = THERMORAWFILEPARSER.out.spectra
-    analytes_tsv_ch     = Channel.value(file(params.analytes_tsv))
+    analytes_tsv_ch     = Channel.value(file(params.analytes_tsv, checkIfExists: true)))
     analyte_ch          = Channel.value(params.analyte)
     rt_tol_ch           = Channel.value(params.rt_tolerance)
     mz_tol_ch           = Channel.value(params.mz_tolerance)

--- a/workflows/ribomsqc.nf
+++ b/workflows/ribomsqc.nf
@@ -36,16 +36,8 @@ workflow RIBOMSQC {
     //
     // MODULE: Run MSNBASEXIC
     //
-
-    mzml_ch = THERMORAWFILEPARSER.out.spectra.map { meta, mzml_file ->
-        tuple(
-            meta,                      
-            mzml_file,
-            file(params.analytes_tsv)
-        )
-    }
-
-    tsv_ch              = Channel.value(file(params.analytes_tsv))
+    mzml_ch             = THERMORAWFILEPARSER.out.spectra
+    analytes_tsv_ch     = Channel.value(file(params.analytes_tsv))
     analyte_ch          = Channel.value(params.analyte)
     rt_tol_ch           = Channel.value(params.rt_tolerance)
     mz_tol_ch           = Channel.value(params.mz_tolerance)
@@ -54,9 +46,10 @@ workflow RIBOMSQC {
     plot_xic_ms2_ch     = Channel.value(params.plot_xic_ms2)
     plot_output_path_ch = Channel.value(params.plot_output_path)
     overwrite_tsv_ch    = Channel.value(params.overwrite_tsv)
-
+    
     MSNBASEXIC(
         mzml_ch,
+        analytes_tsv_ch,
         analyte_ch,
         rt_tol_ch,
         mz_tol_ch,

--- a/workflows/ribomsqc.nf
+++ b/workflows/ribomsqc.nf
@@ -49,15 +49,7 @@ workflow RIBOMSQC {
     
     MSNBASEXIC(
         mzml_ch,
-        analytes_tsv_ch,
-        analyte_ch,
-        rt_tol_ch,
-        mz_tol_ch,
-        ms_level_ch,
-        plot_xic_ms1_ch,
-        plot_xic_ms2_ch,
-        plot_output_path_ch,
-        overwrite_tsv_ch
+        analytes_tsv_ch
     )
 
     ch_versions = ch_versions.mix(MSNBASEXIC.out.versions)


### PR DESCRIPTION
<!--
# nf-core/ribomsqc pull request

Many thanks for contributing to nf-core/ribomsqc!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/ribomsqc/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ribomsqc/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/ribomsqc _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).



This PR refactors the MSNBASEXIC module to accept separate input channels instead of combining them via a tuple.
It improves modularity and aligns with nf-core best practices, as suggested by @JoseEspinosa during code review.
