### PR TITLE
Fix custom configs: uncomment pipeline-specific config line

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -200,7 +200,7 @@ includeConfig params.custom_config_base && (!System.getenv('NXF_OFFLINE') || !pa
 
 
 // Load nf-core/ribomsqc custom profiles from different institutions.
-// includeConfig params.custom_config_base && (!System.getenv('NXF_OFFLINE') || !params.custom_config_base.startsWith('http')) ? "${params.custom_config_base}/pipeline/ribomsqc.config" : "/dev/null"
+includeConfig params.custom_config_base && (!System.getenv('NXF_OFFLINE') || !params.custom_config_base.startsWith('http')) ? "${params.custom_config_base}/pipeline/ribomsqc.config" : "/dev/null"
 
 // Set default registry for Apptainer, Docker, Podman, Charliecloud and Singularity independent of -profile
 // Will not be used unless Apptainer / Docker / Podman / Charliecloud / Singularity are enabled


### PR DESCRIPTION
## Summary
Resolve final nf-core linting failure by enabling pipeline-specific custom configuration support.

## Issue
nf-core linting was failing with:


## Fix Applied
- **Uncommented line 203** in `nextflow.config`:
  ```groovy
  // Before (commented):
  // includeConfig params.custom_config_base && (!System.getenv('NXF_OFFLINE') || !params.custom_config_base.startsWith('http')) ? "${params.custom_config_base}/pipeline/ribomsqc.config" : "/dev/null"
  
  // After (uncommented):  
  includeConfig params.custom_config_base && (!System.getenv('NXF_OFFLINE') || !params.custom_config_base.startsWith('http')) ? "${params.custom_config_base}/pipeline/ribomsqc.config" : "/dev/null"