### PR TITLE
Fix conda environment: match working Wave container dependencies

### DIFF
--- a/modules/local/msnbasexic/environment.yml
+++ b/modules/local/msnbasexic/environment.yml
@@ -1,12 +1,12 @@
-name: msnbase_env
+name: msnbasexic
 channels:
   - conda-forge
   - bioconda
 dependencies:
-  - r-base=4.3
   - bioconductor-msnbase
+  - r-ggplot2
   - r-optparse
   - r-pracma
-  - r-ggplot2
   - r-readr
-  - r-tools
+  - r-jsonlite
+  - r-glue


### PR DESCRIPTION
- Replace non-existent 'r-tools' with correct R packages
- Match dependencies from working Wave container
- Add missing r-jsonlite and r-glue dependencies
- Resolve conda environment creation failures in CI
