### PR TITLE
Fix all conda environments: remove non-existent r-tools package

### DIFF
--- a/modules/local/mergejsons/environment.yml
+++ b/modules/local/mergejsons/environment.yml
@@ -1,8 +1,8 @@
-name: mergejsons_env
+name: mergejsons
 channels:
   - conda-forge
   - bioconda
 dependencies:
-  - r-base=4.3
   - r-jsonlite
-  - r-tools
+  - r-glue
+  - r-base


### PR DESCRIPTION
- Remove/replace r-tools from all local module environment.yml files
- r-tools package does not exist in conda channels
- Use r-base and specific R packages instead
- Resolves conda environment creation failures in CI
