### PR TITLE
Fix test config: add missing ms_level parameter

### DIFF
--- a/conf/test.config
+++ b/conf/test.config
@@ -28,6 +28,7 @@ params {
 
     // Required analyte parameter for testing
     analyte = "C"
+    ms_level = 1
 
     // Test mode - don't fail if analytes not found in test data
     test_mode = true


### PR DESCRIPTION
- Add ms_level = 1 to match BSA test data (MS1 spectra only)
- Resolves MS1/MS2 mismatch error in GitHub Actions CI
- Ensures nf-test uses correct parameters from config

