### PR TITLE
Simplify module: remove test_mode flag, use pipeline params

### DIFF
--- a/modules/local/msnbasexic/main.nf
+++ b/modules/local/msnbasexic/main.nf
@@ -4,9 +4,7 @@ process MSNBASEXIC {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-    // Singularity (ociAutoPull via Wave)
     'community.wave.seqera.io/library/bioconductor-msnbase_r-ggplot2_r-optparse_r-pracma_r-readr:83cd263d3bfd0c9e' :
-    // Docker/Wave
     'community.wave.seqera.io/library/bioconductor-msnbase_r-ggplot2_r-optparse_r-pracma_r-readr:83cd263d3bfd0c9e' }"
 
     input:
@@ -21,11 +19,17 @@ process MSNBASEXIC {
         task.ext.when == null || task.ext.when
 
     script:
-    def args = task.ext.args ?: ''
     """
     msnbasexic.R \\
       --file_name ${mzml_file} \\
       --tsv_name ${tsv_file} \\
-      ${args}
+      --analyte_name ${params.analyte} \\
+      --rt_tol_sec ${params.rt_tolerance} \\
+      --mz_tol_ppm ${params.mz_tolerance} \\
+      --msLevel ${params.ms_level} \\
+      --plot_xic_ms1 ${params.plot_xic_ms1} \\
+      --plot_xic_ms2 ${params.plot_xic_ms2} \\
+      --plot_output_path ${params.plot_output_path} \\
+      --overwrite_tsv ${params.overwrite_tsv}
     """
 }


### PR DESCRIPTION
- Remove non-existent --test_mode flag from R script call
- Use pipeline parameters directly (analyte, ms_level, etc.)
- Remove duplicate parameter passing
- R script already has graceful error handling built-in

